### PR TITLE
Use `mkdirp` to create package paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var fs = require('fs')
 var path = require('path')
+var mkdirp = require('mkdirp')
 var spawn = require('spawn-cmd').spawn
 var RSVP = require('rsvp')
 var rimraf = require('rimraf')
@@ -77,9 +78,8 @@ module.exports.install = function(specPath) {
           .then(function() {
             if (!fs.existsSync(packagePath)) {
               console.log(packageName + ' ' + version + ': Installing')
-              fs.mkdirSync(packagePath)
+              mkdirp.sync(path.join(packagePath, 'node_modules'))
               fs.writeFileSync(packagePath + '/package.json', '{"name":"multidep-dummy","private":true,"description":"multidep-dummy","repository":"http://example.com","license":"MIT"}')
-              fs.mkdirSync(path.join(packagePath, 'node_modules'))
               var cp = spawn('npm', ['install', packageName + '@' + version], {
                 cwd: packagePath,
                 stdio: 'inherit',

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "testing"
   ],
   "dependencies": {
+    "mkdirp": "^0.5.1",
     "rimraf": "^2.4.3",
     "rsvp": "^3.1.0",
     "spawn-cmd": "0.0.2"


### PR DESCRIPTION
This resolves #4 (installing scoped packages) by using `mkdirp.sync()` instead of the regular `fs.mkdirSync()`. Everything else already seems to work fine with scoped packages.